### PR TITLE
feature: clean system log and reset iOS simulator

### DIFF
--- a/clean-mac.bash
+++ b/clean-mac.bash
@@ -57,12 +57,19 @@ while true; do
         printf "\e[0mKilling process before removing(s)\n"
         if [[ $(pgrep -f Flipper.app) ]]; then kill $(pgrep -f Flipper.app); fi
         if [[ $(pgrep -f Xcode.app) ]]; then kill $(pgrep -f Xcode.app); fi
-        killall -9 com.apple.CoreSimulator.CoreSimulatorService
+        sudo killall -9 com.apple.CoreSimulator.CoreSimulatorService &>/dev/null
+        sleep 2
 
         printf "\e[0mRemoving folder(s)\n"
         for ((i = 0; i < ${#FOLDERS[@]}; i++)); do
             sudo rm -rf "${FOLDERS[$i]}"
         done
+        sleep 1
+
+        # Recreate default simulators
+        xcrun simctl list &>/dev/null
+        xcrun simctl erase all
+
         printf "\e[0mComplete\n"
         break
     elif [[ $REPLY =~ ^[Nn]$ ]]; then

--- a/clean-mac.bash
+++ b/clean-mac.bash
@@ -14,6 +14,14 @@ FOLDERS=(
     ~/Library/Developer/Xcode/Archives
     $(getconf DARWIN_USER_CACHE_DIR)org.llvm.clang/ModuleCache
     $(getconf DARWIN_USER_CACHE_DIR)org.llvm.clang.$(whoami)/ModuleCache
+    # Others
+    ~/Library/Developer/CoreSimulator
+    ~/Library/Application\ Support/Flipper
+    ~/Library/Containers/com.apple.AppStore/Data/Library/Caches
+    ~/Library/Logs
+    /var/log
+    /System/Library/Caches/com.apple.coresymbolicationd
+    /Library/Caches/com.apple.iconservices.store
 )
 
 CAN_REMOVE=false

--- a/clean-mac.bash
+++ b/clean-mac.bash
@@ -53,6 +53,12 @@ while true; do
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         printf "\e[0mStart removing folder(s)\n"
         sleep 2
+
+        printf "\e[0mKilling process before removing(s)\n"
+        if [[ $(pgrep -f Flipper.app) ]]; then kill $(pgrep -f Flipper.app); fi
+        if [[ $(pgrep -f Xcode.app) ]]; then kill $(pgrep -f Xcode.app); fi
+        killall -9 com.apple.CoreSimulator.CoreSimulatorService
+
         printf "\e[0mRemoving folder(s)\n"
         for ((i = 0; i < ${#FOLDERS[@]}; i++)); do
             sudo rm -rf "${FOLDERS[$i]}"


### PR DESCRIPTION
**Folders add**
- [x] System log
- [x] iOS simulator

**Kill related process before removing to prevent bug**
- Flipper.app
- XCode.app
- com.apple.CoreSimulator.CoreSimulatorService

**Known issue**
- [x] Simulator seems buggy when cleaning the iOS simulator, need to fix it
